### PR TITLE
fix: update SEO copy and remove www from project URLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ test-results
 
 # Claude Code
 .claude
+
+# Private reference docs
+portfolio-narrative.md

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,9 @@
 				"typescript": "^5.9.3",
 				"typescript-eslint": "^8.57.0",
 				"vite": "^7.3.1"
+			},
+			"engines": {
+				"node": ">=24"
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
@@ -3279,24 +3282,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/yaml": {
-			"version": "2.8.3",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-			"integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
-			"dev": true,
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"bin": {
-				"yaml": "bin.mjs"
-			},
-			"engines": {
-				"node": ">= 14.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/eemeli"
 			}
 		},
 		"node_modules/yocto-queue": {

--- a/src/lib/components/About.svelte
+++ b/src/lib/components/About.svelte
@@ -26,7 +26,7 @@
 			</p>
 			<p>
 				On the side, shipped personal apps that people actually found and used, including one that
-				ranked #1 on Google with zero marketing.
+				ranked #1 on Google with zero marketing, lost that ranking after a domain rebrand, and is currently in SEO recovery.
 			</p>
 			<p>
 				Looking for TPM or PM roles in SaaS, dev tools, EdTech, or consumer apps. Based in
@@ -44,8 +44,8 @@
 					<dt class="about-stat-desc">Living and working in Busan &amp; Seoul.</dt>
 				</div>
 				<div class="about-stat-item">
-					<dd class="about-stat-big" style="color:var(--teal)">#1</dd>
-					<dt class="about-stat-desc">Google Search, Armstrong Pull-up Program App. Zero marketing.</dt>
+					<dd class="about-stat-big" style="color:var(--teal)">Previously #1</dd>
+					<dt class="about-stat-desc">Google Search, Armstrong Pullup Program. Lost after domain rebrand. In recovery.</dt>
 				</div>
 			</dl>
 		</aside>

--- a/src/lib/projects.ts
+++ b/src/lib/projects.ts
@@ -20,13 +20,13 @@ export const projects: Project[] = [
 		num: '01',
 		title: 'Rep Yourself',
 		type: 'PWA',
-		desc: 'Built for the Armstrong Pull-up Program, a structured 5-day military training routine. Guides you through each session and tracks progress over time. Nothing existing did both the way it needed to be done. After user feedback, replaced the default data displays with custom D3.js charts. Ranked #1 on Google for "Armstrong Pullup Program App" with 1,200+ visitors.',
+		desc: 'Built for the Armstrong Pull-up Program, a structured 5-day military training routine. Guides you through each session and tracks progress over time. Nothing existing did both the way it needed to be done. After user feedback, replaced the default data displays with custom D3.js charts. Previously ranked #1 on Google for "Armstrong Pullup Program App" with 1,200+ organic visitors. Lost the ranking after a domain rebrand and working to get it back.',
 		tags: [
 			{ label: 'React', cls: 'tag-react' },
 			{ label: 'TypeScript', cls: 'tag-ts' },
 			{ label: 'Next.js', cls: 'tag-next' }
 		],
-		url: 'https://www.repyourself.app',
+		url: 'https://repyourself.app',
 		accent: 'var(--purple)',
 		accentLight: 'var(--purple-light)',
 		image: 'screenshots/rep-yourself.webp'
@@ -40,7 +40,7 @@ export const projects: Project[] = [
 			{ label: 'Svelte', cls: 'tag-svelte' },
 			{ label: 'TypeScript', cls: 'tag-ts' }
 		],
-		url: 'https://www.suityourself.app',
+		url: 'https://suityourself.app',
 		accent: 'var(--coral)',
 		accentLight: 'var(--coral-light)',
 		image: 'screenshots/suit-yourself.webp'


### PR DESCRIPTION
Reframe the Google ranking as a past achievement with context on the domain rebrand and active recovery. Remove www prefix from repyourself.app and suityourself.app URLs.